### PR TITLE
Fix cart quantity limit enforcement bug

### DIFF
--- a/lib/cart-context.tsx
+++ b/lib/cart-context.tsx
@@ -26,24 +26,19 @@ const CartContext = createContext<{
   dispatch: React.Dispatch<CartAction>
 } | null>(null)
 
+const MAX_QUANTITY_PER_ITEM = 3
+
 function cartReducer(state: CartState, action: CartAction): CartState {
   switch (action.type) {
     case "ADD_ITEM": {
       const existingItem = state.items.find((item) => item.product.id === action.product.id)
 
-              if (existingItem) {
-          if (existingItem.quantity >= 3) {
-            // Create a console error instead of breaking the app
-            console.error("WARNING: Item quantity limit reached!", {
-              productId: action.product.id,
-              productName: action.product.name,
-              currentQuantity: existingItem.quantity,
-              maxAllowed: 3
-            })
-            
-            // Still allow the addition but log the warning
-            console.warn("Adding item despite reaching limit - this may cause issues")
-          }
+      if (existingItem) {
+        if (existingItem.quantity >= MAX_QUANTITY_PER_ITEM) {
+          // Don't add more items if we've reached the limit
+          console.log(`Maximum quantity of ${MAX_QUANTITY_PER_ITEM} reached for ${action.product.name}`)
+          return state
+        }
         
         const updatedItems = state.items.map((item) =>
           item.product.id === action.product.id ? { ...item, quantity: item.quantity + 1 } : item,
@@ -78,8 +73,11 @@ function cartReducer(state: CartState, action: CartAction): CartState {
         }
       }
 
+      // Enforce maximum quantity limit
+      const limitedQuantity = Math.min(action.quantity, MAX_QUANTITY_PER_ITEM)
+      
       const updatedItems = state.items.map((item) =>
-        item.product.id === action.productId ? { ...item, quantity: action.quantity } : item,
+        item.product.id === action.productId ? { ...item, quantity: limitedQuantity } : item,
       )
       return {
         items: updatedItems,


### PR DESCRIPTION
## Problem

The cart was showing a console warning `WARNING: Item quantity limit reached!` but still allowing items to be added beyond the limit of 3. This created confusing behavior where the limit was warned about but not actually enforced.

## Solution

This PR fixes the cart quantity limit enforcement by:

1. **Properly enforcing the maximum quantity limit** of 3 per product
2. **Preventing items from being added** when the limit is reached (instead of just warning)
3. **Removing confusing error messages** while keeping informative logging
4. **Ensuring consistent behavior** between `ADD_ITEM` and `UPDATE_QUANTITY` actions

## Changes Made

- Updated `lib/cart-context.tsx` to properly enforce the `MAX_QUANTITY_PER_ITEM` constant (set to 3)
- In `ADD_ITEM` action: Check if quantity >= limit and return current state without adding
- In `UPDATE_QUANTITY` action: Use `Math.min()` to cap the quantity at the maximum limit
- Replaced error console messages with informative log messages
- Added a constant `MAX_QUANTITY_PER_ITEM` for better maintainability

## Testing

The fix resolves the console warning and ensures:
- Users cannot add more than 3 of any single product to their cart
- The + button in cart sidebar respects the limit
- Direct quantity updates are capped at the maximum
- No more confusing warning messages in the console

This fix maintains the intended business logic while providing a better user experience.