### PR TITLE
Fix cart quantity limit enforcement to prevent exceeding maximum allowed items

### DIFF
--- a/lib/cart-context.tsx
+++ b/lib/cart-context.tsx
@@ -31,19 +31,18 @@ function cartReducer(state: CartState, action: CartAction): CartState {
     case "ADD_ITEM": {
       const existingItem = state.items.find((item) => item.product.id === action.product.id)
 
-              if (existingItem) {
-          if (existingItem.quantity >= 3) {
-            // Create a console error instead of breaking the app
-            console.error("WARNING: Item quantity limit reached!", {
-              productId: action.product.id,
-              productName: action.product.name,
-              currentQuantity: existingItem.quantity,
-              maxAllowed: 3
-            })
-            
-            // Still allow the addition but log the warning
-            console.warn("Adding item despite reaching limit - this may cause issues")
-          }
+      if (existingItem) {
+        if (existingItem.quantity >= 3) {
+          console.error("WARNING: Item quantity limit reached!", {
+            productId: action.product.id,
+            productName: action.product.name,
+            currentQuantity: existingItem.quantity,
+            maxAllowed: 3
+          })
+          
+          // Return current state without modification when limit is reached
+          return state
+        }
         
         const updatedItems = state.items.map((item) =>
           item.product.id === action.product.id ? { ...item, quantity: item.quantity + 1 } : item,
@@ -76,6 +75,22 @@ function cartReducer(state: CartState, action: CartAction): CartState {
           items: updatedItems,
           total: updatedItems.reduce((sum, item) => sum + item.product.price * item.quantity, 0),
         }
+      }
+
+      // Enforce quantity limit of 3 per item
+      if (action.quantity > 3) {
+        const item = state.items.find((item) => item.product.id === action.productId)
+        if (item) {
+          console.error("WARNING: Item quantity limit reached!", {
+            productId: action.productId,
+            productName: item.product.name,
+            requestedQuantity: action.quantity,
+            maxAllowed: 3
+          })
+        }
+        
+        // Return current state without modification when limit would be exceeded
+        return state
       }
 
       const updatedItems = state.items.map((item) =>


### PR DESCRIPTION
## Summary
- Fixed cart quantity limit enforcement that was allowing users to exceed the 3-item per product limit
- Resolved console warning: `WARNING: Item quantity limit reached\!` by properly preventing additions instead of just logging warnings
- Updated both ADD_ITEM and UPDATE_QUANTITY actions in cart reducer to enforce the limit consistently

## Problem
The cart system was logging warnings when users exceeded the 3-item limit but still allowing the additions to proceed. This caused:
- Items to exceed the intended maximum quantity of 3 per product  
- Console warnings being generated but not acted upon
- Inconsistent cart behavior where limits were detected but not enforced

## Solution  
- **ADD_ITEM action**: Now returns current state without modification when attempting to add beyond the 3-item limit
- **UPDATE_QUANTITY action**: Added validation to prevent setting quantities above 3, returning current state if limit would be exceeded
- Maintained existing error logging for debugging and monitoring purposes

## Files Changed
- `lib/cart-context.tsx`: Updated cart reducer logic to properly enforce quantity limits

## Test plan
- [ ] Add an item to cart and verify it can be added up to quantity 3
- [ ] Attempt to add a 4th item and verify it is blocked with console warning
- [ ] Use quantity controls in cart sidebar to verify they respect the 3-item limit  
- [ ] Verify existing cart functionality (remove items, clear cart) continues to work
- [ ] Check that different products can each have up to 3 items independently

🤖 Generated with [Claude Code](https://claude.ai/code)