### PR TITLE
Fix fetch_error exception by removing FakeApiCaller component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import { supabase, type Product } from "@/lib/supabase";
 import { ProductCard } from "@/components/product-card";
 import { CartSidebar } from "@/components/cart-sidebar";
-import { FakeApiCaller } from "@/components/fake-api-caller";
 
 // Mock data fallback when database tables don't exist
 function getMockProducts(): Product[] {
@@ -134,7 +133,6 @@ export default async function Home() {
 
   return (
     <div className="min-h-screen bg-background">
-      <FakeApiCaller />
       <header className="border-b">
         <div className="container mx-auto px-4 py-4 flex justify-between items-center">
           <h1 className="text-2xl font-bold">TechStore</h1>


### PR DESCRIPTION
## Summary
• Removed the FakeApiCaller component that was intentionally making API calls to non-existent endpoints
• This eliminates the fetch_error exception occurring at https://v0-basic-ecommerce-application.vercel.app/
• The component was deliberately calling https://example.com/api/nonexistent-endpoint which would always fail

## Root Cause Analysis
The FakeApiCaller component in `components/fake-api-caller.tsx:11` was making a fetch request to a non-existent endpoint that would always result in a fetch error. This component was imported and used in the main page (`app/page.tsx:4` and `app/page.tsx:137`).

## Changes Made
- Removed `import { FakeApiCaller } from "@/components/fake-api-caller"` from `app/page.tsx:4`
- Removed `<FakeApiCaller />` component usage from `app/page.tsx:137`

## Test Plan
- [x] Verified the component was causing intentional fetch errors
- [x] Removed the component from the main page
- [x] Application should no longer generate fetch_error exceptions

🤖 Generated with [Claude Code](https://claude.ai/code)